### PR TITLE
Bug fix for Predict when the fit run had thinning

### DIFF
--- a/examples/test_pred2.R
+++ b/examples/test_pred2.R
@@ -44,6 +44,7 @@ out2 <- bcf::bcf(y               = y,
                   nsim            = n_sim,
                   w               = weights,
                   n_chains        = 2,
+                  nthin           = 3,
                   update_interval = 1)
 
 cat("BCF run complete\n")

--- a/src/bcf_clean_overpar.cpp
+++ b/src/bcf_clean_overpar.cpp
@@ -320,12 +320,12 @@ List bcfoverparRcppClean(NumericVector y_, NumericVector z_, NumericVector w_,
   treef_con << std::setprecision(save_tree_precision) << xi_con << endl; //cutpoints
   treef_con << ntree_con << endl;  //number of trees
   treef_con << di_con.p << endl;  //dimension of x's
-  treef_con << (int)(nd/thin) << endl;
+  treef_con << nd << endl;
 
   treef_mod << std::setprecision(save_tree_precision) << xi_mod << endl; //cutpoints
   treef_mod << ntree_mod << endl;  //number of trees
   treef_mod << di_mod.p << endl;  //dimension of x's
-  treef_mod << (int)(nd/thin) << endl;
+  treef_mod << nd << endl;
 
   //*****************************************************************************
   /* MCMC


### PR DESCRIPTION
Hey @jaredsmurray,

We noticed a bug when trying to use predict of a run that was fit with thinning. The thining was "double counted"  when the tree output file was saved. It's a simple fix we've included in this PR!

Thanks for your time, and let me know if you have any questions,

Peter